### PR TITLE
update module path

### DIFF
--- a/pkg/scraping/go.mod
+++ b/pkg/scraping/go.mod
@@ -1,4 +1,4 @@
-module scraping
+module github.com/stavia/imdbsoundtracks/pkg/scraping
 
 go 1.12
 


### PR DESCRIPTION
Hello, I am trying to scraping soundtrack information with your package. But I am unable to `go get github.com/stavia/imdbsoundtracks/pkg/scraping` in a project outside `$GOPATH`.

The error message is

```
go: github.com/stavia/imdbsoundtracks/pkg/scraping upgrade => v0.0.0-20200524101155-859145181224
go get: github.com/stavia/imdbsoundtracks/pkg/scraping@v0.0.0-20200524101155-859145181224: parsing go.mod:
        module declares its path as: scraping
                but was required as: github.com/stavia/imdbsoundtracks/pkg/scraping
```

I think we need to declare the module path as `github.com/stavia/imdbsoundtracks/pkg/scraping`.